### PR TITLE
ADD: ER図を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@
 
 ## 画面遷移図
 https://www.figma.com/file/uVVe6a3QC89BlnZ4keeksj/%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=5%3A33
+
+## ER図
+[![Image from Gyazo](https://i.gyazo.com/3bfd82b58163d84cdaf8dfeaba3edd6e.png)](https://i.gyazo.com/3bfd82b58163d84cdaf8dfeaba3edd6e)

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@
 https://www.figma.com/file/uVVe6a3QC89BlnZ4keeksj/%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=5%3A33
 
 ## ER図
-[![Image from Gyazo](https://i.gyazo.com/3bfd82b58163d84cdaf8dfeaba3edd6e.png)](https://i.gyazo.com/3bfd82b58163d84cdaf8dfeaba3edd6e)
+[![Image from Gyazo](https://i.gyazo.com/8e4344b2d9258e81a180392d7c1b162f.png)](https://gyazo.com/8e4344b2d9258e81a180392d7c1b162f)

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@
 https://www.figma.com/file/uVVe6a3QC89BlnZ4keeksj/%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3?node-id=5%3A33
 
 ## ER図
-[![Image from Gyazo](https://i.gyazo.com/8e4344b2d9258e81a180392d7c1b162f.png)](https://gyazo.com/8e4344b2d9258e81a180392d7c1b162f)
+[![Image from Gyazo](https://i.gyazo.com/17748a686cdf3d59fe2c16402bc329dd.png)](https://gyazo.com/17748a686cdf3d59fe2c16402bc329dd)


### PR DESCRIPTION
READMEに下記ER図を追加いたしました。
お手数ですがレビューをお願いいたします。

## ER図 ##
[![Image from Gyazo](https://i.gyazo.com/8384630aa1fd7b09084d242ed6c3f040.png)](https://gyazo.com/8384630aa1fd7b09084d242ed6c3f040)

### keywords ###
夢事典のキーワードを保存するテーブル
- word : キーワード
- connotation : 簡単な意味
- description : 詳細説明

### diaries ###
登録ユーザーが作成した日記を保存するテーブル
- date : 日記の日付
- title : タイトル
- story : 夢の内容

### addings ###
日記にキーワードを登録するため、keywordsとdiariesの中間テーブル。

### users ###
登録ユーザー用テーブル
sorcery使用予定
- name :  アカウント名
- email : メールアドレス
- crypted_password 
- salt
- role(enum  { general: 0, admin: 1 } )